### PR TITLE
Update make_output_files.py

### DIFF
--- a/sandbox/make_output_files.py
+++ b/sandbox/make_output_files.py
@@ -81,7 +81,7 @@ else:
 	output_string = output_string[:-2]
 	colour_string = colour_string[:-2]
 
-if args.heatmap is "F":
+if args.heatmap == "F":
 	print("heatmap script is not executed")
 
 command = "Rscript" # --vanilla --slave < "


### PR DESCRIPTION
Python string comparison using "is" instead of "=="

While exploring the repository, I noticed that in Sandbox/make_output_files.py, string comparison is done using "is":

if args.heatmap is "F":

In newer Python versions, this may lead to unpredictable behavior since "is" checks object identity rather than value equality. It might be safer to use "==".

I would be happy to submit a pull request to fix this and check for similar cases across the repository.